### PR TITLE
isConnected() fix, also smarter use of spl_object_id()

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -355,11 +355,12 @@ class Client implements ServerSetting
         $s = $this->getConnection();
         Connection::send($s, $type, $params);
 
-        if (!is_array(Connection::$waiting[spl_object_id($s)])) {
-            Connection::$waiting[spl_object_id($s)] = [];
+        $key = is_object($s) ? spl_object_id($s) : intval($s);
+        if (!is_array(Connection::$waiting[$key])) {
+            Connection::$waiting[$key] = [];
         }
 
-        Connection::$waiting[spl_object_id($s)][] = $task;
+        Connection::$waiting[$key][] = $task;
     }
 
     /**
@@ -463,7 +464,8 @@ class Client implements ServerSetting
             $task->fail();
             break;
         case 'job_created':
-            $task = array_shift(Connection::$waiting[spl_object_id($s)]);
+            $key = is_object($s) ? spl_object_id($s) : intval($s);
+            $task = array_shift(Connection::$waiting[$key]);
             $task->handle = $resp['data']['handle'];
             if ($task->type == Task::JOB_BACKGROUND) {
                 $task->finished = true;

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -174,7 +174,8 @@ class Connection
             );
         }
 
-        self::$waiting[spl_object_id($socket)] = [];
+        $key = is_object($socket) ? spl_object_id($socket) : intval($socket);
+        self::$waiting[$key] = [];
 
         return $socket;
     }
@@ -371,7 +372,7 @@ class Connection
      */
     public static function isConnected($socket)
     {
-        return $conn !== false;
+        return $socket !== false;
     }
 
     /**


### PR DESCRIPTION
 - isConnected() had a typo
 - using spl_object_id() on the $socket value works for new version of PHP (because it's a Socket object) but not older version (because it's an integer a-la UNIX $fd)